### PR TITLE
Use an HTTPs URL for {{ site.url }}

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ description: Redefining the way VA serves veterans
 
 #URL of site, include http://, do not include a trailing slash
 #url: http://localhost:4000
-url: http://department-of-veterans-affairs.github.io/dsva
+url: https://department-of-veterans-affairs.github.io/dsva
 
 
 


### PR DESCRIPTION
Otherwise https://department-of-veterans-affairs.github.io/dsva/ is plauged by mixed content warnings, and is effectively unusable. HTTPS should work fine from an HTTP page, so that's fine too.
